### PR TITLE
Removed usage of mutable type function

### DIFF
--- a/src/controller/RemoteController.cpp
+++ b/src/controller/RemoteController.cpp
@@ -26,8 +26,12 @@ ModelResponse RemoteController::AddSubTask(const Task& task, const TaskId& paren
     auto response = service::Response();
 
     TaskDTO task_dto;
-    task_dto.mutable_task()->CopyFrom(task);
-    task_dto.mutable_parent_id()->CopyFrom(parent_id);
+
+    auto new_task = std::make_unique<Task>(task);
+    auto new_parent_id = std::make_unique<TaskId>(parent_id);
+
+    task_dto.set_allocated_task(new_task.release());
+    task_dto.set_allocated_parent_id(new_parent_id.release());
 
     auto status = stub_->AddSubTask(&context, task_dto, &response);
 
@@ -39,8 +43,12 @@ ModelResponse RemoteController::Edit(const TaskId& task_id, const Task& task)
     auto response = service::Response();
 
     TaskDTO task_dto;
-    task_dto.mutable_id()->CopyFrom(task_id);
-    task_dto.mutable_task()->CopyFrom(task);
+
+    auto new_id = std::make_unique<TaskId>(task_id);
+    auto new_task = std::make_unique<Task>(task);
+
+    task_dto.set_allocated_id(new_id.release());
+    task_dto.set_allocated_task(new_task.release());
 
     auto status = stub_->Edit(&context, task_dto, &response);
 
@@ -52,9 +60,14 @@ ModelResponse RemoteController::EditSubTask(const TaskId& task_id, const Task& t
     auto response = service::Response();
 
     TaskDTO task_dto;
-    task_dto.mutable_id()->CopyFrom(task_id);
-    task_dto.mutable_task()->CopyFrom(task);
-    task_dto.mutable_parent_id()->CopyFrom(parent_id);
+
+    auto new_id = std::make_unique<TaskId>(task_id);
+    auto new_task = std::make_unique<Task>(task);
+    auto new_parent_id = std::make_unique<TaskId>(parent_id);
+
+    task_dto.set_allocated_id(new_id.release());
+    task_dto.set_allocated_task(new_task.release());
+    task_dto.set_allocated_parent_id(new_parent_id.release());
 
     auto status = stub_->EditSubTask(&context, task_dto, &response);
 

--- a/tests/controller/RemoteControllerTest.cpp
+++ b/tests/controller/RemoteControllerTest.cpp
@@ -43,8 +43,13 @@ TEST_F(RemoteControllerTest, shouldCallAddSubTaskMethod)
     TaskId parent_id{};
 
     TaskDTO request{};
-    request.mutable_task()->CopyFrom(task);
-    request.mutable_parent_id()->CopyFrom(parent_id);
+
+    request.set_allocated_task(
+        std::make_unique<Task>(task).release()
+    );
+    request.set_allocated_parent_id(
+        std::make_unique<TaskId>(parent_id).release()
+    );
 
     EXPECT_CALL(*stub_, AddSubTask(_, request, _))
         .WillOnce(::testing::Return(::grpc::Status::OK));
@@ -62,8 +67,12 @@ TEST_F(RemoteControllerTest, shouldCallEditMethod)
     TaskId task_id{};
 
     TaskDTO request{};
-    request.mutable_task()->CopyFrom(task);
-    request.mutable_id()->CopyFrom(task_id);
+    request.set_allocated_task(
+        std::make_unique<Task>(task).release()
+    );
+    request.set_allocated_id(
+        std::make_unique<TaskId>(task_id).release()
+    );
 
     EXPECT_CALL(*stub_, Edit(_, request, _))
         .WillOnce(::testing::Return(::grpc::Status::OK));
@@ -82,9 +91,16 @@ TEST_F(RemoteControllerTest, shouldCallEditSubTaskMethod)
     TaskId parent_id{};
 
     TaskDTO request{};
-    request.mutable_id()->CopyFrom(task_id);
-    request.mutable_task()->CopyFrom(task);
-    request.mutable_parent_id()->CopyFrom(parent_id);
+
+    request.set_allocated_id(
+        std::make_unique<TaskId>(task_id).release()
+    );
+    request.set_allocated_task(
+        std::make_unique<Task>(task).release()
+    );
+    request.set_allocated_parent_id(
+        std::make_unique<TaskId>(parent_id).release()
+    );
 
     EXPECT_CALL(*stub_, EditSubTask(_, request, _))
         .WillOnce(::testing::Return(::grpc::Status::OK));

--- a/tests/persistence/TaskPersistenceTest.cpp
+++ b/tests/persistence/TaskPersistenceTest.cpp
@@ -16,10 +16,13 @@ TEST(TaskPersisterTest, shouldSerializeAndDeserialize)
     for (size_t i = 0 ; i < 5 ; i++)
     {
         auto tmp = TaskDTO{};
-        auto task = tmp.mutable_task();
+        auto task = std::make_unique<Task>();
+
         task->set_title(std::to_string(i));
         task->set_priority(Task_Priority_kHigh);
         task->set_status(Task_Status_kInProgress);
+
+        tmp.set_allocated_task(task.release());
 
         tasks.emplace_back(tmp);
     }

--- a/tests/server/RequestHandlerImplTest.cpp
+++ b/tests/server/RequestHandlerImplTest.cpp
@@ -40,12 +40,18 @@ TEST_F(RequestHandlerImplTest, shouldCallAddMethod)
 TEST_F(RequestHandlerImplTest, shouldCallAddSubTaskMethod)
 {
     ::grpc::ServerContext context{};
+
     Task task{};
     TaskId parent_id{};
 
     TaskDTO request{};
-    request.mutable_task()->CopyFrom(task);
-    request.mutable_parent_id()->CopyFrom(parent_id);
+
+    request.set_allocated_task(
+        std::make_unique<Task>(task).release()
+    );
+    request.set_allocated_parent_id(
+        std::make_unique<TaskId>(parent_id).release()
+    );
 
     ::service::Response response{};
 
@@ -65,8 +71,12 @@ TEST_F(RequestHandlerImplTest, shouldCallEditMethod)
     TaskId task_id{};
 
     TaskDTO request{};
-    request.mutable_task()->CopyFrom(task);
-    request.mutable_id()->CopyFrom(task_id);
+    request.set_allocated_task(
+        std::make_unique<Task>(task).release()
+    );
+    request.set_allocated_id(
+        std::make_unique<TaskId>(task_id).release()
+    );
 
     ::grpc::ServerContext context{};
     ::service::Response response{};
@@ -91,9 +101,16 @@ TEST_F(RequestHandlerImplTest, shouldCallEditSubTaskMethod)
     TaskId parent_id{};
 
     TaskDTO request{};
-    request.mutable_id()->CopyFrom(task_id);
-    request.mutable_task()->CopyFrom(task);
-    request.mutable_parent_id()->CopyFrom(parent_id);
+
+    request.set_allocated_id(
+        std::make_unique<TaskId>(task_id).release()
+    );
+    request.set_allocated_task(
+        std::make_unique<Task>(task).release()
+    );
+    request.set_allocated_parent_id(
+        std::make_unique<TaskId>(parent_id).release()
+    );
 
     EXPECT_CALL(*model_, EditSubTask(task_id, task, parent_id))
         .WillOnce(::testing::Return(ModelResponse::Success()));


### PR DESCRIPTION
Changes:
- Replaced mutable from `RemoteController`
- Removed mutable from `RequestHandlerImpl`
- Removed mutable from `Tests`